### PR TITLE
Fix live reloading output box

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -27,7 +27,7 @@
     var appendOutput = function(kind, message) {
         var span = document.createElement('span');
         span.classList.add('preview-jsdoc-' + kind);
-        span.innerText = message+'<br/>';
+        span.innerText = message+'\n';
         output.appendChild(span)
     }
     socket.onDidJsDocLogInfo = function (message) {


### PR DESCRIPTION
It used to use `<br>` but then the new lines wouldn't be added, instead a `\n` is used now to show new lines properly.

Fixing #33 